### PR TITLE
Removed non-existing icon "ppt-icon.png"

### DIFF
--- a/src/components/ListItem/ListItem.less
+++ b/src/components/ListItem/ListItem.less
@@ -207,7 +207,7 @@
 
   .ms-ListItem-itemIcon {
     &[class*='ms-ListItem-itemIcon--ppt'] {
-      background-image: url(ppt-icon.png);
+      /*background-image: url(ppt-icon.png);*/
       width: 40px;
       height: 40px;
       margin: 15px;


### PR DESCRIPTION
I got an error message regarding a "non-existing file" while trying to create a bundle with webpack. Usually, webpack loads/inlines all icons relative to their paths. But in this case it couldn't find an icon with that name.